### PR TITLE
determine ->my_home when $ENV{HOME} is empty

### DIFF
--- a/lib/File/HomeDir/Unix.pm
+++ b/lib/File/HomeDir/Unix.pm
@@ -35,7 +35,7 @@ sub my_home {
 
 sub _my_home {
 	my $class = shift;
-	if ( exists $ENV{HOME} and defined $ENV{HOME} ) {
+	if ( exists $ENV{HOME} and length $ENV{HOME} ) {
 		return $ENV{HOME};
 	}
 

--- a/t/20_empty_home.t
+++ b/t/20_empty_home.t
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+
+use strict;
+
+BEGIN {
+	$|         = 1;
+	$^W        = 1;
+	$ENV{HOME} = '';
+}
+
+use Test::More;
+use File::HomeDir;
+
+plan( tests => 1 );
+my $home = ( getpwuid($<) )[7];
+is scalar File::HomeDir->my_home, $home, 'my_home found';


### PR DESCRIPTION
When running a script as MDA under exim, `File::HomeDir->my_home` did not work.
It turned out that this is due to the fact that exim passes an _empty_ enviroment variable `HOME`, which the current implementation of `File::HomeDir->_my_home` returns as possible home directory.

I think it should instead treat an empty `HOME` the same way as a non-existant one and in this case fallback to discovery via `getpwuid()`.